### PR TITLE
Add root page

### DIFF
--- a/BlazorToDoList.App/Pages/_Host.cshtml
+++ b/BlazorToDoList.App/Pages/_Host.cshtml
@@ -1,36 +1,55 @@
-﻿@page "/"
+<!-- The @page directive specifies the URL path for this component. In this case, the component will be rendered at the root URL path ("/"). -->
+@page "/"
+
+<!-- The @namespace directive sets the namespace for this component. In this case, the namespace is set to "BlazorToDoList.App.Pages". -->
 @namespace BlazorToDoList.App.Pages
+
+<!-- The @addTagHelper directive adds all tag helpers from the "Microsoft.AspNetCore.Mvc.TagHelpers" namespace. -->
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<!-- The @{} block allows C# code to be written in the Razor markup. Here, the layout is set to null. -->
 @{
     Layout = null;
 }
 
+<!-- The <!DOCTYPE html> element defines the document type and version. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- The <meta> elements provide metadata about the document. -->
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BlazorApp</title>
+
+    <!-- The <base> element specifies the base URL for all relative URLs in the document. -->
     <base href="~/" />
+
+    <!-- The <link> elements load external stylesheets. -->
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link href="css/site.css" rel="stylesheet" />
 </head>
 <body>
+    <!-- The <app> element is the root component for the Blazor application. -->
     <app>
+        <!-- The <component> element renders the App component in ServerPrerendered mode. -->
         <component type="typeof(App)" render-mode="ServerPrerendered" />
     </app>
 
+    <!-- The <div> element is used to display error messages in the Blazor application. -->
     <div id="blazor-error-ui">
+        <!-- The <environment> element shows different messages based on the current environment (Development, Staging, Production). -->
         <environment include="Staging,Production">
             An error has occurred. This application may no longer respond until reloaded.
         </environment>
         <environment include="Development">
             An unhandled exception has occurred. See browser dev tools for details.
         </environment>
+        <!-- The <a> elements provide options to reload the application or dismiss the error message. -->
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
 
+    <!-- The <script> element loads the Blazor server-side script (blazor.server.js). -->
     <script src="_framework/blazor.server.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds the root page component for the Blazor application. The page is responsible for rendering the root App component in ServerPrerendered mode. It also handles error messages and loads required stylesheets and scripts. The component is rendered at the root URL path ("/").