### PR TITLE
Set MainLayout as layout for the current component

### DIFF
--- a/BlazorToDoList.App/Pages/_Imports.razor
+++ b/BlazorToDoList.App/Pages/_Imports.razor
@@ -1,1 +1,2 @@
-﻿@layout MainLayout
+<!-- The @layout directive sets the layout for the current component. In this case, the "MainLayout" layout will be used for this component. -->
+@layout MainLayout


### PR DESCRIPTION
Sets the "MainLayout" as the layout for the current component. The layout defines the common structure and elements that will be used across multiple pages/components in the application. By specifying the layout using the `@layout` directive, the component will use the "MainLayout" layout for its rendering.