### PR TITLE
 Add FileService for reading and saving data from/to a file

### DIFF
--- a/BlazorToDoList.App/Services/FileService.cs
+++ b/BlazorToDoList.App/Services/FileService.cs
@@ -1,4 +1,4 @@
-﻿using BlazorToDoList.App.Models;
+using BlazorToDoList.App.Models;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
 using System.Collections.Generic;
@@ -6,23 +6,42 @@ using System.IO;
 
 namespace BlazorToDoList.App.Services
 {
+    /// <summary>
+    /// Service responsible for reading and saving data from/to a file.
+    /// </summary>
     public class FileService : IFileService
     {
         private readonly IConfiguration _configuration;
 
+        /// <summary>
+        /// Constructor to initialize the FileService with the provided IConfiguration.
+        /// </summary>
+        /// <param name="configuration">The IConfiguration instance used to access configuration values.</param>
         public FileService(IConfiguration configuration)
         {
             _configuration = configuration;
         }
 
+        /// <summary>
+        /// Read the contents of the file specified in the configuration.
+        /// </summary>
+        /// <returns>The content of the file as a string.</returns>
         public string ReadFromFile()
         {
+            // Read all the text from the file specified in the configuration using the SampleDataFile key.
             return File.ReadAllText(_configuration["SampleDataFile"]);
         }
 
+        /// <summary>
+        /// Save the provided list of ToDoItems to a file specified in the configuration.
+        /// </summary>
+        /// <param name="toDoItems">The list of ToDoItems to be saved.</param>
         public void SaveToFile(List<ToDoItem> toDoItems)
         {
+            // Serialize the list of ToDoItems to JSON format.
             string json = JsonConvert.SerializeObject(toDoItems);
+
+            // Write the serialized JSON data to the file specified in the configuration using the SampleDataFile key.
             System.IO.File.WriteAllText(_configuration["SampleDataFile"], json);
         }
     }


### PR DESCRIPTION
Added  FileService, a service responsible for reading data from and saving data to a file. The service uses Newtonsoft.Json for JSON serialization and utilizes IConfiguration to access configuration values, such as the path to the file to read from and save to. The service supports reading the content of the file as well as saving a list of ToDoItems to the specified file in JSON format.